### PR TITLE
Disable `Lint/EmptyBlock` rule in test files

### DIFF
--- a/boatload.gemspec
+++ b/boatload.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha', '~> 1.11'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 1.0'
+  spec.add_development_dependency 'rubocop', '~> 1.1.0'
   spec.add_development_dependency 'shoulda-context', '~> 2.0'
   spec.add_development_dependency 'yard'
 end

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,4 +1,8 @@
 inherit_from: ../.rubocop.yml
 
+Lint/EmptyBlock:
+  Exclude:
+    - ./**/*_test.rb
+
 Metrics/BlockLength:
   Enabled: false


### PR DESCRIPTION
We're okay with our tests creating empty blocks when the content of the block isn't important to the test.

It seems like it could still be valuable to have this cop run for `test_helper.rb`, so we've only disabled it for the `_test.rb` files.

This fixes these rubocop violations that started happening in v1.1.0
```
Inspecting 14 files
..........WWW.

Offenses:

test/boatload/async_batch_processor_test.rb:22:11: W: Lint/EmptyBlock: Empty block detected.
          AsyncBatchProcessor.new(max_backlog_size: -1) {}
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/async_batch_processor_test.rb:28:11: W: Lint/EmptyBlock: Empty block detected.
          AsyncBatchProcessor.new(max_queue_size: 0) {}
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/async_batch_processor_test.rb:33:15: W: Lint/EmptyBlock: Empty block detected.
        abp = AsyncBatchProcessor.new {}
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/async_batch_processor_test.rb:42:16: W: Lint/EmptyBlock: Empty block detected.
        @abp = AsyncBatchProcessor.new(logger: create_logger) {}
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/timer_test.rb:12:18: W: Lint/EmptyBlock: Empty block detected.
        @timer = Timer.new(queue: @queue, logger: @logger, delivery_interval: @interval) {}
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/worker_test.rb:15:19: W: Lint/EmptyBlock: Empty block detected.
        @worker = Worker.new(queue: @queue, logger: @logger) {}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/boatload/worker_test.rb:78:18: W: Lint/EmptyBlock: Empty block detected.
        worker = Worker.new(queue: @queue, logger: @logger) {}
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

14 files inspected, 7 offenses detected
```