### PR TITLE
Collect code coverage and enforce minimum coverage on CI

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -25,3 +25,9 @@ jobs:
       - run: bin/test
         env:
           TESTOPTS: --verbose
+          MEASURE_COVERAGE: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: coverage/
+          if-no-files-found: error

--- a/boatload.gemspec
+++ b/boatload.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 1.1.0'
   spec.add_development_dependency 'shoulda-context', '~> 2.0'
+  spec.add_development_dependency 'simplecov', '~> 0.19.0'
   spec.add_development_dependency 'yard'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ if ENV['MEASURE_COVERAGE']
   require 'simplecov'
   SimpleCov.start do
     enable_coverage :branch
+    # TODO: minimum_coverage line: 100, branch: 100
+    minimum_coverage line: 99, branch: 91
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,9 @@
 
 if ENV['MEASURE_COVERAGE']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    enable_coverage :branch
+  end
 end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if ENV['MEASURE_COVERAGE']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'boatload'
 


### PR DESCRIPTION
This PR adds [`simplecov`](https://github.com/simplecov-ruby/simplecov) and uses it to measure code coverage and enforce minimum test coverage on CI. There are some existing coverage gaps, so the minimum coverage isn't set to 100% yet. Once we fill those gaps, we can bump that to 💯 

<details>

<summary>Example coverage report screenshots</summary>

![image](https://user-images.githubusercontent.com/1863540/97768717-5f602680-1ae2-11eb-99b7-f16ce45c9242.png)

![image](https://user-images.githubusercontent.com/1863540/97768707-4f484700-1ae2-11eb-84aa-e2354038c904.png)

</details>